### PR TITLE
Lore: world documents for Tavaryn and the Ashlands

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -87,6 +87,95 @@ The underlying antagonist is the **Hollow Court** — a secret society of nobles
 
 ---
 
+## World Lore: Tavaryn
+
+Full lore documents live in `docs/lore/`. This section is the implementation-oriented summary — focusing on world flags, NPC IDs, and design details needed when building the systems. For the narrative version, read the docs.
+
+### The Ashlands — First Region
+
+The starter region. Level 1–10. Built on the ruins of the Emberveil Kingdom (fire mage nation that destroyed itself in a war two centuries ago). Players begin here. Completing the arc unlocks the second character slot and travel to the Mistwood.
+
+**4 locations:**
+
+| Name | Level | Role |
+|---|---|---|
+| Cinder's Rest | 1–3 | Starter hub — blacksmith, inn, bounty board |
+| The Scorched Path | 2–5 | Travel corridor — bandit camps, random encounters |
+| Emberveil Ruins | 5–8 | Mid-region dungeon — class-gated sealed chamber |
+| The Ashen Throne | 8–10 | End-of-region — Hollow Court stronghold, volatile plateau |
+
+**World flags for the Ashlands:**
+- `AshlandsScavengerBounty` — first bounty quest done
+- `ScorchedPathPatrolCleared` — first bandit patrol defeated
+- `DrenMorrowFound` — injured traveler encountered
+- `DrenMorrowAllied` / `DrenMorrowBetrayed` — branching NPC outcome (mutually exclusive)
+- `EmberSealBroken` — sealed chamber accessed (any class)
+- `AshlandsCourtFound` — player found evidence of the Hollow Court
+- `AshlandsCourtExposed` — player learned the Court's name
+- `EmberArtifactSecured` — artifact retrieved before the Court
+- `ThreshDefeated` / `ThreshNegotiated` / `ThreshAlly` — bandit leader outcome (mutually exclusive)
+- `AshlandsComplete` — major objectives done, unlocks next region
+
+---
+
+### NPCs
+
+Five named NPCs. Full profiles in `docs/lore/npcs.md`.
+
+| NPC ID | Name | Role | Location |
+|---|---|---|---|
+| `korin_ashwell` | Korin Ashwell | Blacksmith, shop, minor quest giver | Cinder's Rest |
+| `sera_voss` | Sera Voss | Innkeeper, information hub, first quest giver | Cinder's Rest |
+| `dren_morrow` | Dren Morrow | Injured traveler, failed Court operative, branching choice | Scorched Path |
+| `lira_the_ashen` | Lira the Ashen | Hermit mage, ruins gate, lore source | Emberveil Ruins edge |
+| `commander_thresh` | Commander Thresh | Bandit leader, multiple resolution paths | Scorched Path / Ashen Throne |
+
+**Class-specific access notes:**
+- Lira only speaks to Mage on first encounter; other classes need ≥ 30 reputation (Known tier) or `DrenMorrowAllied`
+- Korin is suspicious of Archers until Known reputation
+- Thresh is more open to negotiation with Warriors (soldier-to-soldier respect)
+- Dren reveals more to Mages (assumes educated = trustworthy)
+
+---
+
+### Enemies
+
+Six enemy types for the Ashlands. Full details in `docs/lore/ashlands.md`.
+
+| Name | Element | Behavior | Level | Notes |
+|---|---|---|---|---|
+| Ash Scavenger | None | Aggressive | 1–2 | Pack animals, teaches basic combat |
+| Scorched Path Bandit | None | Aggressive | 2–4 | Basic melee/ranged, drops weapons + gold |
+| Bandit Enforcer | None | Defensive (heals at <50% HP) | 4–6 | Always with regular bandits |
+| Ember Sprite | Fire | Random | 3–5 | 30% Burn on hit, weak to Ice |
+| Ash Wraith | Fire | Defensive (phases at <30% HP) | 5–8 | Resistant to physical; Mages deal 2× damage |
+| Hollow Court Sentinel | None | Defensive (calls reinforcements at <40% HP) | 7–10 | Always drops Court Sigil on first kill |
+
+---
+
+### First Quest Chain
+
+Four quests that teach each major system. Full details in `docs/lore/ashlands.md`.
+
+| Quest | Giver | Type | Teaches | Flag set |
+|---|---|---|---|---|
+| "Teeth at the Gate" | Sera Voss | Kill 5 Ash Scavengers | Combat basics | `AshlandsScavengerBounty` |
+| "The Scorched Road" | Sera Voss | Travel + defeat bandit patrol | Travel + random encounters | `ScorchedPathPatrolCleared` |
+| "The Stranger's Burden" | Auto-trigger | Find Dren Morrow + choice | World flags + shared consequences | `DrenMorrowAllied` or `DrenMorrowBetrayed` |
+| "Echoes in the Ruins" | Lira the Ashen | Class-gated dungeon | Class-specific mechanics + Court intro | `EmberSealBroken`, `AshlandsCourtFound` |
+
+---
+
+### The Hollow Court — Ashlands Summary
+
+Full profile in `docs/lore/hollow-court.md`.
+
+In the Ashlands, the Court operates through two proxies — Commander Thresh (doesn't know who funds him) and Dren Morrow (a courier who was abandoned). They want the Emberveil Focus artifact from the ruins. Their Sentinels patrol the Ashen Throne and the deep ruins. The arc ends with the player learning the Court's name but not much more — establishing the pattern that repeats in every region.
+
+The Court's long-game goal: repurpose the ancient Compact's magical seals to concentrate power rather than preserve stability. This unfolds across all regions. The player won't understand the full picture until the late game.
+
+---
+
 ## System Plans
 
 These are the systems that need to be built, listed in dependency order.

--- a/docs/lore/ashlands.md
+++ b/docs/lore/ashlands.md
@@ -1,0 +1,258 @@
+# The Ashlands
+
+*The first region. Starter difficulty. The Keeper awakens here.*
+
+---
+
+## Overview
+
+The Ashlands are the scarred remnants of the **Emberveil Kingdom**, consumed two centuries ago in a war between fire mages and a dragon cult. Neither side won. The mage academies burned. The dragon cult collapsed. What was left was a landscape of volcanic rock, perpetual ash-fall, and pockets of magical fire that have been burning ever since.
+
+The rest of Tavaryn largely forgot the Ashlands after the war. No one wants the land. No one trades with it in meaningful volume. The people who live here — maybe a few thousand across the whole region — are the stubborn, the desperate, and those with nowhere else to go.
+
+This is where new Keepers awaken. The Veil between worlds is thinnest where destruction was greatest, and nothing in Tavaryn was more thoroughly destroyed than the Emberveil Kingdom.
+
+**Level range:** 1–10
+**First character slot unlocks at:** Start of game
+**Region completion unlocks:** Travel to the Mistwood, second character slot
+
+---
+
+## Locations
+
+### Cinder's Rest
+*Starter hub. Level 1–3 area.*
+
+A small settlement built around a natural hot spring — warm water, warm rock, and the smell of sulfur. Population roughly forty. It is the closest thing the Ashlands has to a safe town.
+
+The buildings are made of volcanic stone and salvaged metal. The streets are always dusted in grey ash. At night, the distant glow of the Emberveil Ruins is visible on the horizon.
+
+**What's here:**
+- Korin Ashwell's smithy (shop, quest giver)
+- The Dustfall Inn (Sera Voss, information hub, quest board)
+- A small market with basic supplies
+
+**Enemy encounters:** Ash Scavengers near the town gates (patrol range). No serious threats inside town.
+
+**World flags set here:**
+- `AshlandsScavengerBounty` — first bounty quest completed
+- `CindersRestReputation` — tracks regional reputation score
+
+---
+
+### The Scorched Path
+*Travel corridor. Level 2–5 area.*
+
+The old trade road that once connected the Emberveil Kingdom to the western territories. Now mostly abandoned. The canyon walls on either side are charred black. Bandit camps dot the route. Ambushes are common in the narrow sections.
+
+Travelling here triggers random encounter rolls. The further along the path, the tougher the enemies.
+
+**What's here:**
+- Three bandit camps (clearable)
+- Dren Morrow's location (found injured on the road after quest 2)
+- A broken-down merchant wagon (loot opportunity)
+
+**Enemy encounters:** Scorched Path Bandits, Bandit Enforcers
+**World flags set here:**
+- `ScorchedPathPatrolCleared` — first bandit patrol defeated
+- `DrenMorrowFound` — player encounters the injured traveler
+- `DrenMorrowAllied` / `DrenMorrowBetrayed` — branching outcome
+
+---
+
+### Emberveil Ruins
+*Mid-region dungeon. Level 5–8 area.*
+
+What remains of the largest mage academy in the old kingdom. The surface level is a maze of collapsed walls and open sky. The underground chambers are intact — preserved by the same magic that destroyed the kingdom above.
+
+Fire elementals nest in the volcanic vents. Ash Wraiths haunt the old lecture halls. In the deepest chamber, behind a magical seal, is an artifact the Hollow Court has been trying to reach.
+
+**What's here:**
+- Lira the Ashen's camp at the ruin's edge
+- Three dungeon levels: collapsed surface, intact underground, sealed chamber
+- Class-gated entry to the sealed chamber:
+  - Mage: Lira teaches you the counter-spell to break the seal
+  - Warrior: A collapsed east wall can be smashed through (requires Power 15+)
+  - Archer: A ventilation shaft in the north tower provides a back route (requires Perception 12+)
+- Evidence of Hollow Court activity in the sealed chamber (Court tools, a sigil)
+
+**Enemy encounters:** Ember Sprites, Ash Wraiths, Hollow Court Sentinels (deepest level)
+**World flags set here:**
+- `EmberSealBroken` — player accessed the sealed chamber
+- `AshlandsCourtFound` — player found evidence of the Court
+- `EmberArtifactSecured` — player retrieved the artifact before the Court
+
+---
+
+### The Ashen Throne
+*End-of-region content. Level 8–10 area.*
+
+A volcanic plateau at the heart of the Ashlands. An ancient dragon's skeleton sits at the peak, wings spread as if still in flight. The locals call the stone seat between its claws the Ashen Throne and say whoever sits there inherits the dragon's curse.
+
+In reality, the Hollow Court uses the plateau as a meeting point. It is their most secure location in the Ashlands — easily defensible, isolated, and avoided by superstitious locals. Their elite Sentinels patrol it in force.
+
+**What's here:**
+- The dragon skeleton (lore object, origin of the Emberveil War)
+- Hollow Court Sentinel patrols (heaviest concentration in the region)
+- A Court operations tent (readable documents, reveals the Court's name and regional commander)
+- Commander Thresh's fate resolves here if he was not dealt with on the Scorched Path
+
+**Enemy encounters:** Bandit Enforcer + Hollow Court Sentinel (mixed patrols), elite Sentinels
+**World flags set here:**
+- `AshlandsCourtExposed` — player learned the Hollow Court's name
+- `AshlandsComplete` — all major objectives done, unlocks next region
+
+---
+
+## Enemy Roster
+
+### Ash Scavenger
+- **Element:** None
+- **Behavior:** Aggressive — always attacks, no special actions
+- **Level range:** 1–2
+- **Description:** Feral wild dogs that roam the ash wastes in packs. Survive by scavenging ruins and harassing travellers. Attack in groups of 2–3. Low health, low damage. Exist to teach the player basic combat.
+- **Loot:** Scraps (crafting material), 2–5 gold per kill
+- **XP:** 15 per kill
+
+---
+
+### Scorched Path Bandit
+- **Element:** None
+- **Behavior:** Aggressive — attacks immediately, no tactics
+- **Level range:** 2–4
+- **Description:** Desperate outlaws in mismatched armour. Former farmers, miners, or soldiers who ran out of options. They fight with rusty swords and clubs. Some carry shortbows. They're not skilled — they're just hungry and scared.
+- **Loot:** Rusty Sword or Dagger (common rarity), 10–25 gold per kill
+- **XP:** 30 per kill
+
+---
+
+### Bandit Enforcer
+- **Element:** None
+- **Behavior:** Defensive — attacks normally above half health; uses a healing potion when below half health (once per fight). Always appears alongside 1–2 Scorched Path Bandits.
+- **Level range:** 4–6
+- **Description:** Commander Thresh's lieutenants. Better equipped, more experienced, and smart enough to carry supplies. They lead the patrol groups and are the main obstacle on the Scorched Path.
+- **Loot:** Sword or Axe (uncommon rarity), 30–60 gold per kill, occasional Healing Potion
+- **XP:** 60 per kill
+
+---
+
+### Ember Sprite
+- **Element:** Fire — deals fire damage; has a 30% chance per hit to apply **Burn** (damage over time for 3 turns)
+- **Behavior:** Random — attacks, defends, or does nothing each turn (unpredictable feel)
+- **Level range:** 3–5
+- **Weakness:** Ice element deals 1.5× damage
+- **Description:** Small fire elementals that flicker like embers in wind. They dart in, strike, and dart away. Not intelligent — they act on instinct. Found near volcanic vents and the outer ruins.
+- **Loot:** Fire Essence (crafting material, used later), 8–15 gold per kill
+- **XP:** 40 per kill
+
+---
+
+### Ash Wraith
+- **Element:** Fire — deals fire damage; resistant to Physical (0.5× damage from non-elemental weapons)
+- **Behavior:** Defensive — fights normally until below 30% health, then phases out (skips a turn, untargetable, regenerates 10% health). Can phase out once per fight. **Mages deal 2× damage** — the wraiths are vulnerable to directed magical force.
+- **Level range:** 5–8
+- **Description:** The ghosts of mages and students who died when the academy burned. They are not evil — they are trapped, reliving their last moments, unable to move on. They cast fire in the same patterns they used in life. Found in the deeper sections of the ruins.
+- **Loot:** Spell Scroll (random common spell, usable by Mage), 15–30 gold per kill
+- **XP:** 80 per kill
+
+---
+
+### Hollow Court Sentinel
+- **Element:** None
+- **Behavior:** Defensive — attacks normally until below 40% health, then retreats (runs to edge of encounter zone and calls reinforcements: 1 additional Sentinel joins the fight after 1 turn). Can call reinforcements once per fight.
+- **Level range:** 7–10
+- **Description:** Masked soldiers in black and gold armour. They do not speak. They do not negotiate. They are professional, disciplined, and very well equipped compared to anything else in the Ashlands. Their presence here means the Court has been operating in the region for a long time.
+- **Loot:** Quality Sword or Spear (rare rarity), 50–100 gold per kill, **Court Sigil** (key item — always drops from the first Sentinel killed)
+- **XP:** 120 per kill
+- **Note:** The Court Sigil can be shown to Sera Voss or Lira the Ashen to learn the Hollow Court's name, setting `AshlandsCourtFound`.
+
+---
+
+## Quest Chain
+
+### Quest 1: "Teeth at the Gate"
+- **Giver:** Sera Voss (Dustfall Inn, Cinder's Rest)
+- **Type:** Kill quest
+- **Objective:** Kill 5 Ash Scavengers near Cinder's Rest
+- **Reward:** 50 gold, basic weapon upgrade (Korin sharpens one weapon for free), +10 Ashlands reputation
+- **Purpose:** Teaches combat. Enemies are trivial, close to town, no travel required.
+- **Flag set:** `AshlandsScavengerBounty`
+- **World reaction:** Korin acknowledges it next visit — "You're the one who dealt with those dogs? Good."
+- **Unlocks:** Quest 2
+
+---
+
+### Quest 2: "The Scorched Road"
+- **Giver:** Sera Voss (after Quest 1)
+- **Type:** Travel + kill quest
+- **Objective:** Travel to the Scorched Path and defeat the bandit patrol (3 Scorched Path Bandits + 1 Bandit Enforcer)
+- **Reward:** 100 gold, +15 Ashlands reputation
+- **Purpose:** Teaches the travel system and random encounters. Slightly harder combat.
+- **Flag set:** `ScorchedPathPatrolCleared`
+- **World reaction:** Sera tells the player about a man found injured on the road — sets up Quest 3.
+- **Unlocks:** Quest 3 (auto-triggers on next visit to the Scorched Path)
+
+---
+
+### Quest 3: "The Stranger's Burden"
+- **Giver:** Auto-triggers when the player reaches the Scorched Path after Quest 2
+- **Type:** Dialogue + choice quest
+- **Objective:** Find Dren Morrow, injured by the road. Decide what to do.
+
+**Choice A — Help Dren:**
+- Spend a healing item (or have a Mage cast a healing spell)
+- Escort him back to Cinder's Rest
+- Reward: Dren becomes an informant; on subsequent conversations he reveals the existence of "the Court" and their operations in the region. Sets `DrenMorrowAllied`. +20 reputation.
+- Side effect: Dren appears in Cinder's Rest on all future character visits.
+
+**Choice B — Turn Dren in:**
+- Bring him to Korin as a suspicious outsider
+- Reward: 150 gold from Korin, +10 reputation with Korin specifically
+- Side effect: Dren disappears (Court retrieves him). The `DrenMorrowBetrayed` flag delays access to the Court's name until the Emberveil Ruins arc.
+- All characters are affected — if your second character visits the path, Dren is either at the inn or gone.
+
+- **Purpose:** Teaches branching world flags and shows the shared-world mechanic in action. The player sees that their choice affected the world for all their heroes.
+
+---
+
+### Quest 4: "Echoes in the Ruins"
+- **Giver:** Lira the Ashen (edge of the Emberveil Ruins)
+- **Unlock condition:** Ashlands reputation ≥ 30 (Known tier) OR `DrenMorrowAllied` is set (Dren mentioned Lira)
+- **Note:** Lira initially only speaks to Mage characters. Other classes need Known reputation before she'll engage.
+- **Type:** Dungeon exploration + class-gated quest
+- **Objective:** Enter the Emberveil Ruins and reach the sealed chamber.
+
+**Class-specific paths:**
+- **Mage:** Lira teaches you the counter-spell. Enter through the front gate and cast it on the seal.
+- **Warrior:** Find the collapsed east wall in the ruins and smash through it (requires Power ≥ 15).
+- **Archer:** Find the ventilation shaft in the north tower (requires Perception ≥ 12). Discovered by examining a gap in the tower wall.
+
+**Inside the sealed chamber:** A collection of old artifacts, research notes from the pre-war academy, and — if the player examines the workbench — tools and a Court Sigil left by a Hollow Court operative. The artifact itself (an Emberveil Focus) can be taken.
+
+- **Reward:** Class-specific item from the sealed chamber (Mage: Emberveil Staff scroll; Warrior: Dragonshard Armour fragment; Archer: Ash-carved Bow grip), +30 Ashlands reputation, `EmberSealBroken` flag set.
+- **If Court Sigil found:** Sets `AshlandsCourtFound`. Showing it to Sera or Lira reveals the name "Hollow Court."
+- **Purpose:** Teaches class-specific mechanics and demonstrates the value of the roster. Each class gets a unique interaction — players are motivated to return with a different hero.
+- **Unlocks:** Travel to the Ashen Throne (final Ashlands area)
+
+---
+
+## The Hollow Court in the Ashlands
+
+The Court has been present in the Ashlands for years, but they do not want to be known here. They operate through two proxies:
+
+**Proxy 1 — Commander Thresh:** Thresh receives funding and logistical support through a contact he knows only as "the Guild." He believes he's working for a merchant consortium that wants to control the Scorched Path trade route. He does not know the Court exists. If the player exposes this to Thresh (via Dren's information), he reacts with fury and becomes a potential ally rather than an enemy — though the Court will send Sentinels to deal with him regardless.
+
+**Proxy 2 — Dren Morrow:** A low-ranking Court courier. His job was to carry a report on the Emberveil Ruins artifact to his handler. He was ambushed by bandits and his handler abandoned him. He knows the Court exists and knows the codename "the Hollow Court" — but not much more. He is not a loyal operative; he was mostly doing it for the gold.
+
+**Direct presence:** Hollow Court Sentinels patrol the Ashen Throne and the deepest level of the Emberveil Ruins. They are the first time the player fights Court soldiers directly. At the Ashen Throne, a tent containing operational documents names the Court, describes the artifact they want, and mentions "the broader network across Tavaryn."
+
+**Arc conclusion:** The Ashlands arc ends with the player learning:
+1. The Hollow Court exists and has a name
+2. They are interested in the old Emberveil artifact
+3. They operate through proxies across Tavaryn (this is not just a local problem)
+
+This sets up the same pattern repeating in every subsequent region — the Court is always present, always pursuing something, always a layer underneath the surface.
+
+---
+
+*Last updated: April 2026*

--- a/docs/lore/hollow-court.md
+++ b/docs/lore/hollow-court.md
@@ -1,0 +1,95 @@
+# The Hollow Court
+
+*The long-arc antagonist of RPG Manager. Not a single villain — a network.*
+
+---
+
+## What They Are
+
+The Hollow Court is a secret society. Its members are nobles, scholars, and merchants who descend from or serve the interests of Tavaryn's fallen kingdoms. They believe the Ancient Compact and its kingdoms were a mistake — too rigid, too focused on stability rather than progress. They do not mourn the fallen kingdoms. They intend to build something new on the ruins. On their terms.
+
+Their symbol is a **hollow crown** — a crown with no top, representing authority that answers to nothing above it. Their operatives carry a black and gold sigil bearing this design. It is how they identify each other and how players will first learn they exist.
+
+---
+
+## How They Operate
+
+The Hollow Court does not act directly if they can avoid it. They prefer:
+
+**Proxies:** Funding a bandit leader who doesn't know who's paying him. Bribing a merchant guild to control a trade route. Employing a courier who carries sealed letters and asks no questions. Every region has proxies. The proxies don't know each other.
+
+**Layered deniability:** No individual Hollow Court member knows the full picture. Field operatives know their handler's codename but not their real identity. Handlers know their regional mission but not the Court's broader objectives. Only the inner circle — the **Eight Hollow Thrones** — know everything.
+
+**Long timelines:** The Court has been operating in the Ashlands for at least two years before the player arrives. They plan in decades. A failed operation is a setback, not a defeat.
+
+---
+
+## Their Presence by Region
+
+### The Ashlands
+*See [ashlands.md](ashlands.md) for full detail.*
+
+- Funding Commander Thresh's bandit operation via an anonymous "merchant guild" contact
+- Attempting to retrieve an artifact from the sealed chamber of the Emberveil Ruins (the Emberveil Focus)
+- Operating through couriers, including Dren Morrow
+- Hollow Court Sentinels present at the Ashen Throne and the deep ruins
+- The Ashlands arc ends with the player *learning the Court exists* — but not much more
+
+### The Mistwood (planned)
+*Details to be written when the Mistwood region is developed.*
+
+The Court's presence here relates to the ancient fey contracts that govern the forest. They want to void an old agreement that limits construction and resource extraction in the region. Their proxy is a lumber consortium.
+
+### Further regions
+*To be determined as each region is developed.*
+
+---
+
+## The Eight Hollow Thrones
+
+The inner circle of the Hollow Court. These are the people who set strategy, resolve internal disputes, and hold the full picture. They are never encountered directly until very late in the game.
+
+Each Throne has a title, not a name — their identities are known only within the Court. The player will gradually learn the titles through intelligence gathered across regions:
+
+| Title | Known details |
+|---|---|
+| The First Throne | Court founder, believed to be very old, never confirmed alive by evidence |
+| The Archivist | Controls information flow, operates through scholars and scribes |
+| The Merchant Prince | Controls the economic proxies across all regions |
+| The General | Commands the Sentinel corps and all military operations |
+| The Diplomat | Manages relationships with legitimate governments and guilds |
+| The Shadow | Handles operations that cannot be acknowledged even within the Court |
+| The Heir | The Court's chosen next leader, identity completely unknown |
+| The Empty Throne | Always vacant — a reminder that power should never feel secure |
+
+The player will not meet any of them until the final arc. They will know their titles long before they know their faces.
+
+---
+
+## Hollow Court Sentinels
+
+The Court's personal soldiers. Not large in number — quality over quantity. They are professional, silent, and very well equipped compared to anything the player encounters in the early regions.
+
+**Identifying features:**
+- Black and gold armour
+- Full-face masks (no visible identity)
+- Move in small, coordinated squads
+- Never speak
+
+Sentinels are deployed for high-value operations. Finding them in the Ashlands — a backwater nobody cares about — is a signal that whatever the Court wants from the Emberveil Ruins is very important to them.
+
+---
+
+## What They Want (The Long Game)
+
+The Hollow Court's ultimate goal is not conquest in the traditional sense. They do not want a kingdom. They want a **system**: a Tavaryn where power flows to those capable of accumulating it, with no ancient compacts or magical seals limiting that accumulation.
+
+The Emberveil Focus (the artifact in the Ashlands) is one piece of a larger puzzle. The Court is collecting artifacts and knowledge from the fallen kingdoms because they believe the ancient seals that stabilized Tavaryn can be *repurposed* — not broken, but redirected. Instead of keeping chaos out, they could be used to concentrate and direct power in specific ways.
+
+This is why they need scholars (the Archivist), control of trade (the Merchant Prince), and military force (the General). The end goal requires all three.
+
+Whether their plan would actually work — and whether the consequences of repurposing the old seals would be as controlled as they believe — is a question the game's later regions are designed to answer.
+
+---
+
+*Last updated: April 2026*

--- a/docs/lore/npcs.md
+++ b/docs/lore/npcs.md
@@ -1,0 +1,150 @@
+# NPC Profiles — The Ashlands
+
+*Five named NPCs for the Ashlands region. Each has a role, a personality, and class-specific dialogue hooks.*
+
+---
+
+## Korin Ashwell
+**Role:** Blacksmith of Cinder's Rest. Shop owner, minor quest giver.
+**Location:** Cinder's Rest (smithy)
+**NPC ID:** `korin_ashwell`
+
+**Background:** Korin has run the only smithy in the Ashlands for twenty years. He came here after a failed business in the west — won't say what happened, doesn't like being asked. He's built a decent life in Cinder's Rest and is deeply protective of it. Gruff, honest, not warm but not cruel. He lost his apprentice to a bandit ambush on the Scorched Path six months ago. He hasn't replaced the boy.
+
+**Personality:** Practical. Measures people by what they do, not what they say. Doesn't trust strangers until they've proven themselves.
+
+**Dialogue hooks by class:**
+- **Warrior:** Korin respects fighters. After the player clears the Scavenger bounty, he offers to upgrade a weapon for free. After the Scorched Path bandits are dealt with, he mentions his apprentice — if the player agrees to look for the boy's hammer in the bandit camp, Korin rewards them with a rare weapon.
+- **Mage:** Korin is cautious around magic-users — too many bad memories from the old kingdom. He'll trade but won't offer extra quests until Trusted reputation. At Trusted, he confides that a cloaked figure has been buying weapons in bulk "for a mining operation" — which is suspicious, because there are no active mines in the Ashlands.
+- **Archer:** Suspicious from the start. "Sneaky types always bring trouble." He'll sell to an Archer but charges slightly higher prices until Known reputation. At Known, he softens — "You're still here. Most sneaky types aren't."
+
+**Reputation reactions:**
+- Stranger: Neutral service, no extras
+- Known: Acknowledges the player's deeds, slight price discount
+- Trusted: Shares the cloaked-buyer information (Hollow Court lead), offers rare stock
+- Honored: Treats the player like a friend, maximum discount, tells his full backstory
+
+**Quest hooks:**
+- "Teeth at the Gate" — rewards the player after Sera sends them (acknowledges the bounty was cleared)
+- "The Apprentice's Hammer" — optional side quest at Known reputation: find the apprentice's hammer in the bandit camp, reward is a rare melee weapon
+
+---
+
+## Sera Voss
+**Role:** Innkeeper of the Dustfall Inn. Primary information source. First quest giver.
+**Location:** Cinder's Rest (Dustfall Inn)
+**NPC ID:** `sera_voss`
+
+**Background:** Sera was an adventurer for fifteen years — explored the Mistwood, fought in the border skirmishes on the eastern frontier, survived things she won't describe in detail. A bad injury to her left leg ended that life. She came to the Ashlands to be somewhere quiet, bought the inn, and has been running it ever since. She knows the region better than anyone and has contacts in every corner of it.
+
+**Personality:** Sharp, observant, dry humour. She has seen too much to be surprised by anything. She talks to everyone who passes through and remembers all of it.
+
+**Dialogue hooks:**
+- Serves as the player's information board — knows the region's history, the factions, the dangers
+- First quest giver for "Teeth at the Gate" and "The Scorched Road"
+- After Quest 2, tells the player about Dren Morrow being found on the road
+- At Known reputation: starts hinting that the bandit operation feels too organized for desperate outlaws
+- At Trusted: confirms "someone from outside is funding them — I've seen this pattern before, in the east"
+- If `DrenMorrowAllied`: Sera can identify the Court Sigil if shown one — "I've seen this before. The Hollow Court. I didn't know they were here."
+- If `AshlandsCourtExposed`: her tone shifts — she becomes more urgent, less casual. She's worried.
+
+**Class reactions:**
+- No strong class preference. Treats all classes professionally.
+- Slightly warmer to Archers (shared background in scouting and mobility)
+- Will ask a Mage about the ruins at some point — she's curious, not hostile
+
+**Quest hooks:**
+- Main quest giver for quests 1 and 2
+- Optional: "The Old Patrol Route" — mapping quest at Known reputation, opens up a faster travel path through the Ashlands
+
+---
+
+## Dren Morrow
+**Role:** Injured traveler. Hollow Court low-level operative. Branching choice NPC.
+**Location:** The Scorched Path (found during Quest 3)
+**NPC ID:** `dren_morrow`
+**Flags:** `DrenMorrowFound`, `DrenMorrowAllied`, `DrenMorrowBetrayed`
+
+**Background:** Dren is twenty-six and has made a lot of bad decisions. The most recent was accepting a courier job from a well-paying anonymous client. The job was fine for three months — pick up a sealed letter here, deliver it there, don't open it. Then his handler stopped responding and bandits ambushed his cart on the Scorched Path. His horse is dead. He has a broken rib and a gash on his leg. Nobody is coming for him.
+
+He knows he was working for someone called the Hollow Court. He knows his handler's codename. He doesn't know what's in the letters he carried, what the Court wants, or who they are beyond being "organized and wealthy."
+
+**Personality:** Scared and trying to hide it. Talks too much when nervous. Not brave but not without conscience — he knew the work felt wrong, he just needed the money.
+
+**Dialogue — Help path:**
+- Grateful, desperate, honest once he feels safe
+- Tells the player about the Court's name and that they're interested in something in the Emberveil Ruins
+- After being brought to Cinder's Rest, becomes a contact at the Dustfall Inn
+- On future visits: provides scraps of Court intelligence picked up from his courier days (activates quest hooks in later regions)
+
+**Dialogue — Betray path:**
+- Never seen again after being handed to Korin
+- Korin receives payment from "guild representatives" the next day — the Court retrieved their asset quietly
+- The Court Sigil becomes the only route to learning the faction name (from the Emberveil Ruins)
+
+**Class reactions:**
+- Responds more openly to Mage characters (assumes mages are educated and won't just kill him)
+- Nervous around Warriors ("please don't hurt me — I'll tell you everything")
+- Wary of Archers ("you're not going to shoot me, are you?")
+
+---
+
+## Lira the Ashen
+**Role:** Hermit mage. Survivor of the Emberveil War. Gate to the ruins questline.
+**Location:** Edge of the Emberveil Ruins
+**NPC ID:** `lira_the_ashen`
+
+**Background:** Lira was sixteen when the academy burned. She survived because she was in the sub-basement collecting herbs when the fire began. She has lived near the ruins ever since — ninety years now, sustained by old Emberveil magic she won't fully explain. She is the last living person who was there during the war. She has watched the ruins for decades, cataloguing what remains, keeping the most dangerous things contained.
+
+She is sharp-minded but speaks in a way that assumes the listener already knows the context. She jumps topics. She references people who died before the player was born as if they're still around.
+
+**Personality:** Erratic, intensely focused, occasionally frightening. Not malicious — just very old and not fully oriented to the present.
+
+**Access conditions:**
+- Only speaks to Mage characters on first encounter (recognises the magic, feels safer)
+- Other classes need Ashlands reputation ≥ 30 (Known tier) before she'll engage
+- Exception: if `DrenMorrowAllied`, Dren mentions her name and she'll speak to anyone the Keeper sends
+
+**Dialogue hooks:**
+- The gate to Quest 4 ("Echoes in the Ruins")
+- Teaches the Mage the counter-spell for the seal
+- Knows the history of the Emberveil War in full detail — extensive optional lore dialogue
+- If the player brings her the Court Sigil: "The Hollow Crown. Yes. They've been trying to get inside for two years. They want the Focus." Sets `AshlandsCourtFound`.
+- If `EmberArtifactSecured`: "Good. Keep it away from them. I don't know what they want it for, but anything they want that badly is something they should not have."
+
+**Quest hooks:**
+- Quest 4 giver
+- Optional: "What the Academy Knew" — translate old Emberveil research notes for her, rewards a spell scroll and deeper lore about the original Compact
+
+---
+
+## Commander Thresh
+**Role:** Bandit leader. Regional antagonist. Potential ally.
+**Location:** Scorched Path (bandit camp), later the Ashen Throne
+**NPC ID:** `commander_thresh`
+**Flags:** `ThreslDefeated`, `ThreshNegotiated`, `ThreshAlly`
+
+**Background:** Thresh was a soldier in the eastern border guard for twelve years. When the garrison was disbanded and the pay stopped — no warning, no reason given — he and forty of his men were just left in the field. He led them west. The Ashlands were the only place no one would come looking for deserters. He didn't plan to become a bandit. He just needed to keep his men fed.
+
+Three months after arriving, a contact found him — well-dressed, too clean for the Ashlands, offering gold for a simple service: control the Scorched Path, keep other traders off it. He took the money. He didn't ask who was paying.
+
+He knows what he's doing is wrong. He's made peace with it. Or he tells himself he has.
+
+**Personality:** Military bearing that hasn't faded. Direct. Doesn't enjoy cruelty but will use it when necessary. Genuinely cares about the men under his command.
+
+**Encounter paths:**
+
+**Path A — Combat:** The player fights Thresh in his camp or at the Ashen Throne. He is a hard fight (Bandit Enforcer level stats + above). If defeated, the bandit operation collapses, Cinder's Rest is safer, and the player receives significant gold and reputation. World flag: `ThreshDefeated`.
+
+**Path B — Negotiation:** Accessible if the player has Known reputation with Thresh's camp (achieved by completing bounties without killing everyone) and does not attack on sight. Thresh is willing to talk. If the player shares Dren's information — that his "Guild" contact is the Hollow Court and he's being used — Thresh is furious. He agrees to pull his men off the Scorched Path in exchange for safe passage out of the Ashlands. World flag: `ThreshNegotiated`. NPCs in Cinder's Rest react differently depending on the outcome — some prefer a dead bandit leader; others appreciate the bloodless resolution.
+
+**Path C — Alliance:** Accessible only if `ThreshNegotiated` and the player has Trusted reputation. Thresh agrees to keep an eye on Hollow Court movements in the Ashlands. He becomes an intelligence contact, providing information once per session. World flag: `ThreshAlly`. The Court sends a Sentinel team to deal with him shortly after — the player can optionally protect him.
+
+**Class reactions:**
+- Respects Warriors as equals (soldier to soldier)
+- Distrusts Mages ("academy types think they're above all of us")
+- Surprisingly respectful of skilled Archers ("I had one like you. Best scout I ever had.")
+
+---
+
+*Last updated: April 2026*

--- a/docs/lore/tavaryn.md
+++ b/docs/lore/tavaryn.md
@@ -1,0 +1,61 @@
+# Tavaryn — World Overview
+
+*This document will grow as new regions are written. For now it establishes the foundation that all regions build on.*
+
+---
+
+## The World
+
+Tavaryn is a continent of old scars and older ruins. It was once a network of powerful kingdoms held together by the **Ancient Compact** — a series of agreements, sealed by magic, between the great ruling houses. The Compact kept the peace for three centuries.
+
+Then the kingdoms fell. Not all at once, not to a single enemy. One collapsed to civil war. Another to plague. A third was consumed by its own mage-lords. The Compact has no kingdoms left to enforce it. What remains is a continent of city-states, wilderness, and ruins — each region shaped by how its kingdom died.
+
+Tavaryn is not in immediate crisis. Life goes on. People trade, argue, fall in love, and die of old age. But something is wrong underneath all of it. The old Compact's magical foundations are eroding. Sealed ruins are waking up. Factions are filling the power vacuum left by the fallen houses, and not all of them have good intentions.
+
+---
+
+## The Keeper of Destiny
+
+You are not a character in this world — you are something older. The Keeper of Destiny is an entity that exists outside the normal flow of time, able to perceive the world but not directly act in it. You work through **bonds**: attaching your awareness to a mortal hero, perceiving what they perceive, guiding their choices.
+
+You are not omnipotent. You can only be bonded to one hero at a time. You cannot force your champions to act — you can only offer them insight and direction. And when a hero dies, the bond is severed. You must find a new champion.
+
+Why the Keeper exists, and where they came from, is a question the game never fully answers. The world's scholars and mystics have theories. None agree.
+
+---
+
+## The Hollow Court
+
+The most significant threat in Tavaryn is not a monster or a war. It is a network.
+
+The **Hollow Court** is a secret society composed of nobles, merchants, and scholars descended from the fallen kingdoms. They believe that the old kingdoms fell because the Ancient Compact was too rigid — that it prevented the natural accumulation of power by those capable of using it. Their goal is not to restore the old world, but to ensure the next one is built on their terms.
+
+They operate through proxies. A merchant guild here, a mercenary company there. They rarely act directly. Their signature is a black and gold sigil — a hollow crown. When the Keeper's heroes begin encountering their operatives, they will not know the Court's name at first. They will only see patterns.
+
+The Hollow Court is the long-arc antagonist of the game. They are not fought in one battle. They are exposed and dismantled, piece by piece, across all regions.
+
+---
+
+## Regions
+
+| Region | Status | Tone | Keeper Level |
+|---|---|---|---|
+| The Ashlands | In development | Ruined, volcanic, sparse | Starter |
+| The Mistwood | Planned | Ancient forest, fey magic | Mid |
+| Frostmere | Planned | Frozen tundra, undead | Hard |
+| The Sunken Reach | Planned | Flooded ruins, sea creatures | Hard |
+| The Void Spire | Planned | Hollow Court stronghold, final arc | End game |
+
+Each region has its own history, factions, enemies, and Hollow Court presence. Completing a region's main arc unlocks travel to the next.
+
+---
+
+## The Ashlands
+
+See [ashlands.md](ashlands.md) for the full region writeup.
+
+The Ashlands are the first region the Keeper awakens in. They are the ruins of the Emberveil Kingdom — a nation of fire mages that destroyed itself in a war with a dragon cult two centuries ago. The ground is still warm. The ruins still burn. It is a hard place to live, but people do live here — because land that no one else wants is at least land you can call your own.
+
+---
+
+*Last updated: April 2026*


### PR DESCRIPTION
## Summary

- **docs/lore/tavaryn.md** — world overview: the Ancient Compact, why the kingdoms fell, the Keeper of Destiny, the Hollow Court, region table
- **docs/lore/ashlands.md** — complete first region: 4 locations with descriptions and world flags, 6 enemy types with stats/behaviors/loot, 4-quest starter chain, Hollow Court proxy operations
- **docs/lore/npcs.md** — full profiles for all 5 Ashlands NPCs (Korin Ashwell, Sera Voss, Dren Morrow, Lira the Ashen, Commander Thresh) — backstory, personality, class-specific dialogue hooks, reputation reactions
- **docs/lore/hollow-court.md** — faction overview, the Eight Hollow Thrones, long-game objectives, per-region presence
- **CLAUDE.md** — new World Lore section with the implementation-oriented summary of locations, NPC IDs, enemy table, quest chain, and world flags

## Purpose

These documents serve as the creative and design reference for building the Ashlands — the first playable region. Every system (combat, quests, dialogue, travel) will be built against this lore, not the other way around.

## Test plan

- [ ] Read through docs/lore/ files and confirm NPC names, location names, and world flags are consistent across all four documents and CLAUDE.md
- [ ] Confirm docs/lore/ folder is visible and navigable on GitHub

🤖 Generated with [Claude Code](https://claude.ai/claude-code)