### PR TITLE
Stop intro typing on resize; update roadmap

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -139,11 +139,11 @@ The long-term goal is a fully playable, story-driven console RPG where:
 
 > Automatically generated from RPGManagerLib source files.
 
-_Last updated: **2026-04-23 14:14**_
+_Last updated: **2026-04-28 02:09**_
 
 ### 📊 Codebase Stats
 - **Namespaces:** 14
-- **Classes:** 34
+- **Classes:** 38
 - **Unique Methods:** 33
 - **Pending TODOs:** 23
 
@@ -271,10 +271,18 @@ _No unique public methods found._
 
 _No unique public methods found._
 
+### [HuntingBow.cs](https://github.com/tombomeke-ehb/RPGManager/main/RPGManagerLib/Items/Weapons/Bows/HuntingBow.cs)
+*Inherits from: `Bow`*  
+_No unique public methods found._
+
 ### [SimpleBow.cs](https://github.com/tombomeke-ehb/RPGManager/main/RPGManagerLib/Items/Weapons/Bows/SimpleBow.cs)
 *Inherits from: `Bow`*  
 > A basic bow with common stats suitable for early gameplay.
 
+_No unique public methods found._
+
+### [WarBow.cs](https://github.com/tombomeke-ehb/RPGManager/main/RPGManagerLib/Items/Weapons/Bows/WarBow.cs)
+*Inherits from: `Bow`*  
 _No unique public methods found._
 
 
@@ -306,6 +314,14 @@ _No unique public methods found._
 
 
 ## 🧭 RPGManagerLib.Items.Weapons.Quivers
+
+### [BigQuiver.cs](https://github.com/tombomeke-ehb/RPGManager/main/RPGManagerLib/Items/Weapons/Quivers/BigQuiver.cs)
+*Inherits from: `Quiver`*  
+_No unique public methods found._
+
+### [MediumQuiver.cs](https://github.com/tombomeke-ehb/RPGManager/main/RPGManagerLib/Items/Weapons/Quivers/MediumQuiver.cs)
+*Inherits from: `Quiver`*  
+_No unique public methods found._
 
 ### [SmallQuiver.cs](https://github.com/tombomeke-ehb/RPGManager/main/RPGManagerLib/Items/Weapons/Quivers/SmallQuiver.cs)
 *Inherits from: `Quiver`*  

--- a/RPGManager/Program.cs
+++ b/RPGManager/Program.cs
@@ -1,5 +1,6 @@
 using RPGManagerLib.Saves;
 using RPGManagerLib.UI;
+using System.Linq;
 
 namespace RPGManager
 {
@@ -70,11 +71,28 @@ namespace RPGManager
                 "and let the tale begin."
             };
 
-            foreach (string line in storyLines)
+            // Remember the starting console width. If the user resizes the window during the animation
+            // we'll stop the typing animation and render the remaining text immediately to avoid
+            // visual reflow/jumps.
+            int initialWidth = GetUsableWindowWidth();
+
+            for (int i = 0; i < storyLines.Length; i++)
             {
+                string line = storyLines[i];
+
                 if (IsSkipRequested())
                 {
                     RenderFullIntroBody(storyLines);
+                    WaitForEnterRealm();
+                    return;
+                }
+
+                // If the window was resized since the intro started, stop animating and render the
+                // remaining lines immediately centered using the current console width. This avoids
+                // lines shifting unexpectedly while typing.
+                if (GetUsableWindowWidth() != initialWidth)
+                {
+                    RenderFullIntroBody(storyLines.Skip(i));
                     WaitForEnterRealm();
                     return;
                 }

--- a/RPGManagerLib/RPGManagerLib.csproj
+++ b/RPGManagerLib/RPGManagerLib.csproj
@@ -5,4 +5,8 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>
+
+  <ItemGroup>
+    <Folder Include="Items\Weapons\Melee\Axes\" />
+  </ItemGroup>
 </Project>


### PR DESCRIPTION
Prevent visual reflow during the intro by recording the initial console width and aborting the typing animation if the window is resized; remaining lines are rendered immediately (uses System.Linq and RenderFullIntroBody with Skip). Also added a Folder Include for Items\Weapons\Melee\Axes in the RPGManagerLib csproj. Updated ROADMAP: timestamp, class count, and added entries for HuntingBow, WarBow, BigQuiver and MediumQuiver.